### PR TITLE
feat: Add integration tests for @editing.progress REST API views

### DIFF
--- a/eea/progress/editing/tests/test_restapi.py
+++ b/eea/progress/editing/tests/test_restapi.py
@@ -1,0 +1,90 @@
+"""Integration tests for eea.progress.editing REST API views
+
+Uses direct view instantiation to test without RelativeSession.
+"""
+
+import unittest
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from transaction import commit
+from eea.progress.editing.tests.base import FUNCTIONAL_TESTING
+
+
+class TestEditingProgressSetup(unittest.TestCase):
+    """Test eea.progress.editing installation"""
+
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_product_installed(self):
+        """Test that eea.progress.editing is installed"""
+        from Products.CMFPlone.utils import get_installer
+        installer = get_installer(self.portal, self.layer["request"])
+        self.assertTrue(installer.is_product_installed("eea.progress.editing"))
+
+    def test_portal_exists(self):
+        """Test that portal is set up"""
+        self.assertIsNotNone(self.portal)
+
+
+class TestEditingProgressView(unittest.TestCase):
+    """Test editing.progress view classes"""
+
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_editing_progress_adapter_registered(self):
+        """Test that EditingProgress adapter class exists"""
+        from eea.progress.editing.restapi.get import EditingProgress
+        self.assertIsNotNone(EditingProgress)
+
+    def test_editing_progress_on_site_root(self):
+        """Test EditingProgress on site root returns basic structure"""
+        from eea.progress.editing.restapi.get import EditingProgress
+        ep = EditingProgress(self.portal, self.portal.REQUEST)
+        result = ep(expand=False)
+        self.assertIn("editing.progress", result)
+        self.assertIn("@id", result["editing.progress"])
+
+    def test_editing_progress_get_class_exists(self):
+        """Test that EditingProgressGet class exists"""
+        from eea.progress.editing.restapi.get import EditingProgressGet
+        self.assertIsNotNone(EditingProgressGet)
+
+
+class TestEditingProgressOnDocument(unittest.TestCase):
+    """Test editing.progress on content objects"""
+
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.portal.invokeFactory("Document", "test-doc", title="Test Document")
+        commit()
+
+    def test_editing_progress_on_document(self):
+        """Test EditingProgress on a Document"""
+        from eea.progress.editing.restapi.get import EditingProgress
+        doc = self.portal["test-doc"]
+        ep = EditingProgress(doc, self.portal.REQUEST)
+        result = ep(expand=True)
+        self.assertIn("editing.progress", result)
+
+    def test_editing_progress_has_done_on_document(self):
+        """Test that EditingProgress on Document has done field"""
+        from eea.progress.editing.restapi.get import EditingProgress
+        doc = self.portal["test-doc"]
+        ep = EditingProgress(doc, self.portal.REQUEST)
+        result = ep(expand=True)
+        self.assertIn("done", result["editing.progress"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eea/progress/editing/tests/test_restapi.py
+++ b/eea/progress/editing/tests/test_restapi.py
@@ -22,6 +22,7 @@ class TestEditingProgressSetup(unittest.TestCase):
     def test_product_installed(self):
         """Test that eea.progress.editing is installed"""
         from Products.CMFPlone.utils import get_installer
+
         installer = get_installer(self.portal, self.layer["request"])
         self.assertTrue(installer.is_product_installed("eea.progress.editing"))
 
@@ -42,11 +43,13 @@ class TestEditingProgressView(unittest.TestCase):
     def test_editing_progress_adapter_registered(self):
         """Test that EditingProgress adapter class exists"""
         from eea.progress.editing.restapi.get import EditingProgress
+
         self.assertIsNotNone(EditingProgress)
 
     def test_editing_progress_on_site_root(self):
         """Test EditingProgress on site root returns basic structure"""
         from eea.progress.editing.restapi.get import EditingProgress
+
         ep = EditingProgress(self.portal, self.portal.REQUEST)
         result = ep(expand=False)
         self.assertIn("editing.progress", result)
@@ -55,6 +58,7 @@ class TestEditingProgressView(unittest.TestCase):
     def test_editing_progress_get_class_exists(self):
         """Test that EditingProgressGet class exists"""
         from eea.progress.editing.restapi.get import EditingProgressGet
+
         self.assertIsNotNone(EditingProgressGet)
 
 
@@ -72,6 +76,7 @@ class TestEditingProgressOnDocument(unittest.TestCase):
     def test_editing_progress_on_document(self):
         """Test EditingProgress on a Document"""
         from eea.progress.editing.restapi.get import EditingProgress
+
         doc = self.portal["test-doc"]
         ep = EditingProgress(doc, self.portal.REQUEST)
         result = ep(expand=True)
@@ -80,6 +85,7 @@ class TestEditingProgressOnDocument(unittest.TestCase):
     def test_editing_progress_has_done_on_document(self):
         """Test that EditingProgress on Document has done field"""
         from eea.progress.editing.restapi.get import EditingProgress
+
         doc = self.portal["test-doc"]
         ep = EditingProgress(doc, self.portal.REQUEST)
         result = ep(expand=True)


### PR DESCRIPTION
Added 8 integration tests covering:
- Product installation verification
- EditingProgress adapter class existence
- EditingProgress on site root (basic structure)
- EditingProgress on Document content (done field)
- EditingProgressGet class import

All tests pass with `eeacms/plone-test:6` Docker image.